### PR TITLE
Bug Fix: Activity Log Tasks Modal displays Tasks from day before lower bound date

### DIFF
--- a/ics/v11/queries/tasks.py
+++ b/ics/v11/queries/tasks.py
@@ -3,10 +3,21 @@ from django.db.models import F, Q, Count, Case, When, Min, Value, Subquery, Oute
 from django.contrib.postgres.search import SearchVector, SearchQuery, SearchRank
 from ics.models import *
 import datetime
+import pytz
+
+
+def filter_by_created_at_range(query_params, queryset):
+	start = query_params.get('start', None)
+	end = query_params.get('end', None)
+	if start is not None and end is not None:
+		dt = datetime.datetime
+		start_date = pytz.utc.localize(dt.strptime(start, constants.DATE_FORMAT))
+		end_date = pytz.utc.localize(dt.strptime(end, constants.DATE_FORMAT))
+		return queryset.filter(created_at__range=(start_date, end_date))
+	return queryset
 
 
 def tasks(query_params):
-	dt = datetime.datetime
 	queryset = Task.objects.filter(is_trashed=False).order_by('process_type__x').annotate(
 		total_amount=Sum(Case(
 			When(items__is_virtual=True, then=Value(0)),
@@ -53,15 +64,7 @@ def tasks(query_params):
 	if flagged and flagged.lower() == 'true':
 		queryset = queryset.filter(is_flagged=True)
 
-	# filter according to date creation, based on parameters
-	start = query_params.get('start', None)
-	end = query_params.get('end', None)
-	if start is not None and end is not None:
-		start = start.strip().split('-')
-		end = end.strip().split('-')
-		startDate = datetime.date(int(start[0]), int(start[1]), int(start[2]))
-		endDate = datetime.date(int(end[0]), int(end[1]), int(end[2]))
-		queryset = queryset.filter(created_at__date__range=(startDate, endDate))
+	queryset = filter_by_created_at_range(query_params, queryset)
 
 
 	# make sure that we get at least one input unit and return it along with the task

--- a/ics/v11/views.py
+++ b/ics/v11/views.py
@@ -209,7 +209,7 @@ class TeamCreate(generics.CreateAPIView):
 ######################
 
 class TaskFilter(django_filters.rest_framework.FilterSet):
-  created_at = django_filters.DateFilter(name="created_at", lookup_expr="startswith")
+  created_at = django_filters.DateTimeFilter(name="created_at", lookup_expr="startswith")
   class Meta:
       model = Task
       fields = ['created_at', 'is_open']
@@ -607,13 +607,7 @@ class ActivityList(generics.ListAPIView):
     queryset = Task.objects.filter(is_trashed=False, process_type__team_created_by=team)\
       .select_related('process_type', 'product_type')
 
-    start = self.request.query_params.get('start', None)
-    end = self.request.query_params.get('end', None)
-    if start is not None and end is not None:
-      dt = datetime.datetime
-      start_date = pytz.utc.localize(dt.strptime(start, constants.DATE_FORMAT))
-      end_date = pytz.utc.localize(dt.strptime(end, constants.DATE_FORMAT))
-      queryset = queryset.filter(created_at__range=(start_date, end_date))
+    queryset = filter_by_created_at_range(self.request.query_params, queryset)
 
     flagged = self.request.query_params.get('flagged', None)
     if flagged and flagged.lower() == 'true':


### PR DESCRIPTION
## Bug:
Christina emailed me pointing out that the Activity Log returns Tasks (in the Task modal) from __before__ the lower bound date (eg Aug 14th-Aug 14th query includes results from Aug 13th). This is because we were querying for Tasks Aug 14th-Aug 14th in local time, which returns earlier tasks when interpreted as UTC (meaning we could possibly leave out Tasks created __late__ Aug 14th, too).

## Fix:
I simply refactored and re-used existing code to fix it.

Note that I changed our Task FilterSet to _DateTimeFilter_ from DateFilter to prevent this issue from happening in the future. Though, for that to work, `created_at` needs to be specified in ISO (which is in UTC and has timezone), so to be honest I'm unsure if this fixes the problem... would love thoughts on this.