### PR TITLE
Display inventory items cost backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ staticfiles
 .env
 db.sqlite3
 node_modules/
+.vscode
 .DS_Store
 .idea
 dump.sql
@@ -11,3 +12,5 @@ local-env
 .pytest_cache
 
 local-env.sh
+local-env.env
+.pycharmrc

--- a/ics/v11/queries/inventory.py
+++ b/ics/v11/queries/inventory.py
@@ -86,6 +86,8 @@ def get_adjusted_item_cost(process_type, product_type):
 		).annotate(
 			cumulative_cost_offset=F('amount_diff')*F('cumulative_cost_per_unit'),
 		).order_by('amount_diff_abs').first()
-	
-	return item.cumulative_cost + item.cumulative_cost_offset
+	total_cumulative_cost = item.cumulative_cost + item.cumulative_cost_offset
+	if total_cumulative_cost < 0:
+		return 0
+	return total_cumulative_cost
 	

--- a/ics/v11/queries/inventory.py
+++ b/ics/v11/queries/inventory.py
@@ -43,7 +43,6 @@ def old_inventory_used_amount(items_query):
 def get_adjusted_amount(process_type, product_type):
 	start_time = None
 	starting_amount = 0
-	#print('process_type={}, product_type={}'.format(process_type, product_type))
 	latest_adjustment = Adjustment.objects \
 		.filter(process_type=process_type, product_type=product_type) \
 		.order_by('-created_at').first()

--- a/ics/v11/queries/inventory.py
+++ b/ics/v11/queries/inventory.py
@@ -39,3 +39,45 @@ def old_inventory_used_amount(items_query):
 	fully_used_amount = (items_query.filter(inputs__isnull=False, inputs__amount__isnull=True).distinct().aggregate(amount=Sum('amount'))['amount'] or 0)
 	partially_used_amount = (items_query.filter(inputs__isnull=False, inputs__amount__isnull=False).aggregate(amount=Sum('inputs__amount'))['amount'] or 0)
 	return fully_used_amount + partially_used_amount
+
+def get_adjusted_amount(process_type, product_type):
+	start_time = None
+	starting_amount = 0
+	#print('process_type={}, product_type={}'.format(process_type, product_type))
+	latest_adjustment = Adjustment.objects \
+		.filter(process_type=process_type, product_type=product_type) \
+		.order_by('-created_at').first()
+
+	if latest_adjustment:
+		start_time = latest_adjustment.created_at
+		starting_amount = latest_adjustment.amount
+
+	data = inventory_amounts(process_type, product_type, start_time, None)
+	return starting_amount + data['created_amount'] - data['used_amount']
+
+def get_adjusted_cost(process_type, product_type):
+	cost = 0
+	amount_remaining = get_adjusted_amount(process_type, product_type)
+	items = Item.objects \
+		.filter(
+			creating_task__is_trashed=False,
+			creating_task__process_type=process_type,
+			creating_task__product_type=product_type,
+		).annotate(
+			cost=F('creating_task__cost')
+		).order_by('-created_at')
+
+	for item in items:
+		#print('Item: amount={}, cost={}, created_at={}'.format(item.amount, item.cost, item.created_at))
+		if amount_remaining > 0:
+			if amount_remaining - item.amount >= 0:
+				cost += item.cost
+				amount_remaining -= item.amount
+			else: 
+				ratio = item.cost / item.amount
+				cost += ratio * amount_remaining
+				amount_remaining = 0
+		else:
+			break
+	return cost
+	

--- a/ics/v11/serializers.py
+++ b/ics/v11/serializers.py
@@ -11,7 +11,7 @@ from ics.utilities import *
 import operator
 import pytz
 import re
-from ics.v11.queries.inventory import inventory_amounts, old_inventory_created_amount, old_inventory_used_amount
+from ics.v11.queries.inventory import get_adjusted_amount, get_adjusted_cost, old_inventory_created_amount, old_inventory_used_amount
 from django.contrib.postgres.aggregates.general import ArrayAgg
 
 
@@ -906,16 +906,23 @@ class ClearUserProfileTokenSerializer(serializers.ModelSerializer):
 class AdjustmentSerializer(serializers.ModelSerializer):
 	created_at = serializers.DateTimeField(read_only=True)
 	amount = serializers.DecimalField(max_digits=10, decimal_places=3, coerce_to_string=False)
+	cost = serializers.SerializerMethodField()
+
+	def get_cost(self, adjustment):
+		process_type = adjustment.process_type_id
+		product_type = adjustment.product_type_id
+		return get_adjusted_cost(process_type, product_type)
 
 	class Meta:
 		model = Adjustment
-		fields = ('userprofile', 'created_at', 'process_type', 'product_type', 'amount', 'explanation')
+		fields = ('userprofile', 'created_at', 'process_type', 'product_type', 'amount', 'cost', 'explanation')
 
 
 class InventoryList2Serializer(serializers.Serializer):
 	process_type = serializers.SerializerMethodField()
 	product_types = serializers.SerializerMethodField()
-	adjusted_amount = serializers.SerializerMethodField(source='get_adjusted_amount')
+	adjusted_amount = serializers.SerializerMethodField()
+	adjusted_cost = serializers.SerializerMethodField()
 
 	def get_adjusted_amount(self, item_summary):
 		process_type = item_summary['creating_task__process_type']
@@ -923,20 +930,17 @@ class InventoryList2Serializer(serializers.Serializer):
 		total_adjusted_amount = 0
 
 		for product_type in product_types:
-			start_time = None
-			starting_amount = 0
-			latest_adjustment = Adjustment.objects \
-				.filter(process_type=process_type, product_type=product_type, userprofile__team=item_summary['team_inventory']) \
-				.order_by('-created_at').first()
-
-			if latest_adjustment:
-				start_time = latest_adjustment.created_at
-				starting_amount = latest_adjustment.amount
-
-			data = inventory_amounts(process_type, product_type, start_time, None)
-			total_adjusted_amount += starting_amount + data['created_amount'] - data['used_amount']
-
+			total_adjusted_amount += get_adjusted_amount(process_type, product_type)
 		return total_adjusted_amount
+
+	def get_adjusted_cost(self, item_summary):
+		process_type = item_summary['creating_task__process_type']
+		product_types = list(set(item_summary['product_type_ids']))
+		total_cost = 0
+
+		for product_type in product_types:
+			total_cost += get_adjusted_cost(process_type, product_type)
+		return total_cost
 
 	def get_process_type(self, item):
 		return {
@@ -957,6 +961,44 @@ class InventoryList2Serializer(serializers.Serializer):
 				'code': item_summary['product_type_codes'][i],
 			}
 		return product_types_dict.values()
+
+class InventoryList2AggregateSerializer(serializers.Serializer):
+	category = serializers.SerializerMethodField()
+	process_type = serializers.SerializerMethodField()
+	product_types = serializers.SerializerMethodField()
+	adjusted_cost = serializers.SerializerMethodField()
+
+	def get_category(self, item_summary):
+		return item_summary['creating_task__process_type__category']
+
+	def get_process_type(self, item):
+		return {
+			'id': item['creating_task__process_type'],
+			'name': item['creating_task__process_type__name'],
+			'code': item['creating_task__process_type__code'],
+			'unit': item['creating_task__process_type__unit'],
+			'icon': item['creating_task__process_type__icon'],
+			'category': item['creating_task__process_type__category'],
+		}
+	
+	def get_product_types(self, item_summary):
+		product_types_dict = {}
+		for i, id in enumerate(item_summary['product_type_ids']):
+			product_types_dict[id] = {
+				'id': id,
+				'name': item_summary['product_type_names'][i],
+				'code': item_summary['product_type_codes'][i],
+			}
+		return product_types_dict.values()
+
+	def get_adjusted_cost(self, item_summary):
+		process_type = item_summary['creating_task__process_type']
+		product_types = list(set(item_summary['product_type_ids']))
+		total_cost = 0
+
+		for product_type in product_types:
+			total_cost += get_adjusted_cost(process_type, product_type)
+		return total_cost
 
 
 class ItemSummarySerializer(serializers.Serializer):

--- a/ics/v11/urls.py
+++ b/ics/v11/urls.py
@@ -98,6 +98,7 @@ urlpatterns = [
     url(r'^adjustments/$', views.CreateAdjustment.as_view(), name='adjustments'),
 
     url(r'^inventories/$', views.InventoryList2.as_view(), name='inventories'),
+    url(r'^inventories/aggregate/$', views.InventoryList2Aggregate.as_view(), name='inventories-aggregate'),
 
     url(r'^adjustment-history/$', views.AdjustmentHistory.as_view(), name='adjustment-history'),
 

--- a/ics/v11/views.py
+++ b/ics/v11/views.py
@@ -1060,7 +1060,7 @@ class InventoryList2(generics.ListAPIView):
 
     ordering_values = ['creating_task__process_type__name']
 
-    #Unless aggregate product param is true, return a separate row for each product type
+    # Unless aggregate product param is true, return a separate row for each product type
     if not aggregate_products or aggregate_products.lower() != 'true':
       queryset_values.append('creating_task__product_type')
       ordering_values.append('creating_task__product_type__name')
@@ -1071,6 +1071,64 @@ class InventoryList2(generics.ListAPIView):
       product_type_codes=ArrayAgg('creating_task__product_type__code'),
     ).order_by(*ordering_values)
 
+class InventoryList2Aggregate(generics.ListAPIView):
+  serializer_class = InventoryList2AggregateSerializer
+
+  def get_queryset(self):
+    queryset = Item.active_objects.filter(creating_task__is_trashed=False)
+
+    team = self.request.query_params.get('team', None)
+    if team is None:
+      raise serializers.ValidationError('Request must include "team" query param')
+
+    # filter by team
+    queryset = queryset.filter(team_inventory=team)
+
+    category_types = self.request.query_params.get('category_types', None)
+    if category_types is not None:
+      category_codes = category_types.strip().split(',')
+      queryset = queryset.filter(creating_task__process_type__category__in=category_codes)
+
+    process_types = self.request.query_params.get('process_types', None)
+    if process_types is not None:
+      process_ids = process_types.strip().split(',')
+      queryset = queryset.filter(creating_task__process_type__in=process_ids)
+
+    product_types = self.request.query_params.get('product_types', None)
+    if product_types is not None:
+      product_ids = product_types.strip().split(',')
+      queryset = queryset.filter(creating_task__product_type__in=product_ids)
+
+    aggregate_products = self.request.query_params.get('aggregate_products', None)
+
+    queryset_values = [
+      'creating_task__process_type',
+      'creating_task__process_type__name',
+      'creating_task__process_type__unit',
+      'creating_task__process_type__code',
+      'creating_task__process_type__icon',
+      'creating_task__process_type__category',
+      'team_inventory',
+    ]
+    ordering_values = ['category_order', 'creating_task__process_type__name']
+
+    if process_types is not None or process_types is not None:
+      queryset_values.append('creating_task__product_type')
+      ordering_values.append('creating_task__product_type__name')
+    
+    return queryset.values(*queryset_values).annotate(
+      product_type_ids=ArrayAgg('creating_task__product_type'),
+      product_type_names=ArrayAgg('creating_task__product_type__name'),
+      product_type_codes=ArrayAgg('creating_task__product_type__code'),
+    ).annotate(
+      category_order=Case( 
+        When(creating_task__process_type__category='rm', then=Value(0)), 
+        When(creating_task__process_type__category='wip', then=Value(1)), 
+        When(creating_task__process_type__category='fg', then=Value(2)),
+        default=Value(3),
+        output_field=models.IntegerField(),
+      )
+    ).order_by(*ordering_values)
 
 class AdjustmentHistory(APIView):
   def set_params(self):

--- a/ics/v11/views.py
+++ b/ics/v11/views.py
@@ -501,7 +501,7 @@ class InventoryList(generics.ListAPIView):
       'creating_task__process_type__created_by__username',
       'creating_task__process_type__created_by',).annotate(
         count=Sum('amount'),
-      ).annotate(oldest=Min('creating_task__created_at'))
+        ).annotate(oldest=Min('creating_task__created_at'))
 
 # inventory/detail-test/
 class InventoryDetailTest2(generics.ListAPIView):
@@ -1046,20 +1046,30 @@ class InventoryList2(generics.ListAPIView):
       category_codes = category_types.strip().split(',')
       queryset = queryset.filter(creating_task__process_type__category__in=category_codes)
 
-    return queryset.values(
+    aggregate_products = self.request.query_params.get('aggregate_products', None)
+
+    queryset_values = [
       'creating_task__process_type',
       'creating_task__process_type__name',
       'creating_task__process_type__unit',
       'creating_task__process_type__code',
       'creating_task__process_type__icon',
       'creating_task__process_type__category',
-      'creating_task__product_type',
-      'creating_task__product_type__name',
-      'creating_task__product_type__code',
       'team_inventory'
-    ).annotate(
-      total_amount=Sum('amount'),
-    ).order_by('creating_task__process_type__name', 'creating_task__product_type__name')
+    ] 
+
+    ordering_values = ['creating_task__process_type__name']
+
+    #Unless aggregate product param is true, return a separate row for each product type
+    if not aggregate_products or aggregate_products.lower() != 'true':
+      queryset_values.append('creating_task__product_type')
+      ordering_values.append('creating_task__product_type__name')
+
+    return queryset.values(*queryset_values).annotate(
+      product_type_ids=ArrayAgg('creating_task__product_type'),
+      product_type_names=ArrayAgg('creating_task__product_type__name'),
+      product_type_codes=ArrayAgg('creating_task__product_type__code'),
+    ).order_by(*ordering_values)
 
 
 class AdjustmentHistory(APIView):

--- a/ics/v11/views.py
+++ b/ics/v11/views.py
@@ -1146,7 +1146,7 @@ class AdjustmentHistory(APIView):
 
   def get_adjustments(self):
     queryset = Adjustment.objects\
-      .filter(process_type=self.process_type, product_type=self.product_type, userprofile__team=self.team)\
+      .filter(process_type=self.process_type, product_type=self.product_type)\
       .order_by('-created_at')
     return queryset.all()
 

--- a/ics/v11/views.py
+++ b/ics/v11/views.py
@@ -1072,7 +1072,7 @@ class InventoryList2(generics.ListAPIView):
     ).order_by(*ordering_values)
 
 class InventoryList2Aggregate(generics.ListAPIView):
-  serializer_class = InventoryList2AggregateSerializer
+  serializer_class = InventoryList2Serializer
 
   def get_queryset(self):
     queryset = Item.active_objects.filter(creating_task__is_trashed=False)


### PR DESCRIPTION
Do not review until PR https://github.com/polymerteam/wafflecone/pull/210 is merged into the cogs branch. 

The changes in this PR are used in order to display aggregate cost totals on the inventory screen. It would be very helpful if someone could closely review my queries and see if there is a more efficient way of accessing this data. There are some weird nuances to aggregating cost when there are inventory adjustments, so the solution was no obvious to me.