### PR TITLE
Fix broken post_delete flag handler

### DIFF
--- a/ics/async_actions.py
+++ b/ics/async_actions.py
@@ -111,11 +111,7 @@ def input_update(**kwargs):
 
 
 @task
-def handle_flag_update_after_input_delete(**kwargs):
-	child_task_id = kwargs['taskID']
-	former_parent_task_id = kwargs['creatingTaskID']
-	former_parent_task_flagged_ancestors_id_string = kwargs['creating_task_flagged_ancestors_id_string']
-
+def handle_flag_update_after_input_delete(child_task_id, former_parent_task_id, former_parent_task_flagged_ancestors_id_string):
 	child_task = Task.objects.get(pk=child_task_id)
 	former_parent_task = Task.objects.get(pk=former_parent_task_id)
 

--- a/ics/signals.py
+++ b/ics/signals.py
@@ -102,9 +102,11 @@ def input_deleted_pre_delete(sender, instance, **kwargs):
 def input_deleted(sender, instance, **kwargs):
 	kwargs1 = { 'taskID' : instance.task.id, 'creatingTaskID' : instance.input_item.creating_task.id}
 	check_anomalous_inputs_alerts(**kwargs1)
-	kwargs2 = get_input_kwargs(instance)
-	if kwargs2:
-		handle_flag_update_after_input_delete(**kwargs2)
+
+	child_task_id = instance.task.id
+	parent_task_id = instance.input_item.creating_task.id
+	former_parent_task_flagged_ancestors_id_string = instance.input_item.creating_task.flagged_ancestors_id_string
+	handle_flag_update_after_input_delete(child_task_id, parent_task_id, former_parent_task_flagged_ancestors_id_string)
 
 
 @receiver(post_save, sender=TaskIngredient)


### PR DESCRIPTION
get_input_kwargs would return Null if there's no task ingredient, which there ISN'T post_delete for the last input -- meaning we'd not update flags for final inputs 😢 	. 
Instead, we just pass the parameters we need directly every time there's an input delete since they don't depend on there being a task ingredient in existence.