### PR TITLE
BUG FIX: Run input delete on each child for orphan task deletion 

### DIFF
--- a/ics/signals.py
+++ b/ics/signals.py
@@ -121,49 +121,6 @@ def ingredient_updated(sender, instance, **kwargs):
 
 # HELPER FUNCTIONS
 
-# Returns None of if no TaskIngredient exists (eg for old tasks)
-def get_input_kwargs(instance, added=False):
-	task_ingredient_qs = TaskIngredient.objects.filter(
-																			task=instance.task.id,
-																			ingredient__process_type_id=instance.input_item.creating_task.process_type_id,
-																			ingredient__product_type_id=instance.input_item.creating_task.product_type_id,
-																		)
-	task_ingredient = task_ingredient_qs.count() > 0 and task_ingredient_qs[0]
-	if not task_ingredient:  # Impossible to proceed
-		return
-
-	task_ingredient__actual_amount = float(task_ingredient.actual_amount)
-	process_type = task_ingredient.ingredient.process_type.id
-	product_type = task_ingredient.ingredient.product_type.id
-	recipe_exists_for_ingredient = instance.task.recipe and Ingredient.objects.filter(
-		recipe=instance.task.recipe,
-		process_type=process_type,
-		product_type=product_type,
-	).count()
-	num_similar_inputs = Input.objects.filter(
-		task=instance.task,
-		input_item__creating_task__product_type=instance.input_item.creating_task.product_type,
-		input_item__creating_task__process_type=instance.input_item.creating_task.process_type,
-	).count()
-	adding_first_or_deleting_last_input = num_similar_inputs == 1  # both cases same since we use pre_delete and post_save
-
-	return {
-		'taskID': instance.task.id,
-		'task_flagged_ancestors_id_string': instance.task.flagged_ancestors_id_string,
-		'creatingTaskID': instance.input_item.creating_task.id,
-		'creating_task_flagged_ancestors_id_string': instance.input_item.creating_task.flagged_ancestors_id_string,
-		'added': added,
-		'input_id': instance.id,
-		'process_type': process_type,
-		'product_type': product_type,
-		'task_ingredient__actual_amount': task_ingredient__actual_amount,
-		'input_item__creating_task__product_type': instance.input_item.creating_task.product_type_id,
-		'input_item__creating_task__process_type': instance.input_item.creating_task.process_type_id,
-		'recipe_exists_for_ingredient': recipe_exists_for_ingredient,
-		'adding_first_or_deleting_last_input': adding_first_or_deleting_last_input,
-	}
-
-
 # NOTE: This logic, identical to original implementation, can produce negative actual_amounts since it blindly subtracts
 # the input_item's full amount, for example even if the ingredient amount for the ingredient has been reduced.
 def update_task_ingredient_after_input_delete(instance, just_calculate_new_amount=False):


### PR DESCRIPTION
## Fixes bug where siblings of a deleted task wouldn't update properly if it was an orphan.
To note:
- get_input_kwargs moved to helper file since it's used more generally now
- clarified the names of the parent input task ingredients